### PR TITLE
chore(version): bump version to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moneytrackio-conseiljs",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Client-side library for Tezos dApp development.",
   "browser": "dist/index-web.js",
   "main": "dist/index.js",


### PR DESCRIPTION
the version 2.0.1 was built without including the fix of the negative
offset